### PR TITLE
Declare explicit animationController in TasksGridState

### DIFF
--- a/projects/habit_tracker_flutter/lib/ui/home/tasks_grid.dart
+++ b/projects/habit_tracker_flutter/lib/ui/home/tasks_grid.dart
@@ -27,6 +27,11 @@ class TasksGrid extends StatefulWidget {
 
 class TasksGridState extends State<TasksGrid>
     with SingleTickerProviderStateMixin {
+  // * By declaring the [AnimationController] explicitly here, we ensure it does
+  // * not get disposed when the [TasksGrid] is disposed.
+  // * This is necessary when the page flip effect takes place, as the parent
+  // * widget still holds onto a GlobalKey, meaning that the animationController
+  // * will be needed again later (hence it should **not** be disposed).
   late final animationController =
       AnimationController(vsync: this, duration: Duration(milliseconds: 300));
 

--- a/projects/habit_tracker_flutter/lib/ui/home/tasks_grid.dart
+++ b/projects/habit_tracker_flutter/lib/ui/home/tasks_grid.dart
@@ -7,7 +7,6 @@ import 'package:habit_tracker_flutter/models/front_or_back_side.dart';
 import 'package:habit_tracker_flutter/models/task.dart';
 import 'package:habit_tracker_flutter/ui/add_task/add_task_navigator.dart';
 import 'package:habit_tracker_flutter/ui/add_task/task_details_page.dart';
-import 'package:habit_tracker_flutter/ui/animations/animation_controller_state.dart';
 import 'package:habit_tracker_flutter/ui/animations/custom_fade_transition.dart';
 import 'package:habit_tracker_flutter/ui/animations/staggered_scale_transition.dart';
 import 'package:habit_tracker_flutter/ui/common_widgets/edit_task_button.dart';
@@ -23,11 +22,13 @@ class TasksGrid extends StatefulWidget {
   final VoidCallback? onAddOrEditTask;
 
   @override
-  TasksGridState createState() => TasksGridState(Duration(milliseconds: 300));
+  TasksGridState createState() => TasksGridState();
 }
 
-class TasksGridState extends AnimationControllerState<TasksGrid> {
-  TasksGridState(Duration duration) : super(duration);
+class TasksGridState extends State<TasksGrid>
+    with SingleTickerProviderStateMixin {
+  late final animationController =
+      AnimationController(vsync: this, duration: Duration(milliseconds: 300));
 
   bool _isEditing = false;
 

--- a/projects/habit_tracker_flutter/lib/ui/home/tasks_grid.dart
+++ b/projects/habit_tracker_flutter/lib/ui/home/tasks_grid.dart
@@ -28,7 +28,8 @@ class TasksGrid extends StatefulWidget {
 class TasksGridState extends State<TasksGrid>
     with SingleTickerProviderStateMixin {
   // * By declaring the [AnimationController] explicitly here, we ensure it does
-  // * not get disposed when the [TasksGrid] is disposed.
+  // * not get disposed when the [TasksGrid] is disposed (as it would be the
+  // * case if we used the [AnimationControllerState] helper).
   // * This is necessary when the page flip effect takes place, as the parent
   // * widget still holds onto a GlobalKey, meaning that the animationController
   // * will be needed again later (hence it should **not** be disposed).


### PR DESCRIPTION
Avoids it being disposed and throwing exceptions during page flip.

Closes #3 