### PR TITLE
Package updates (may 2023)

### DIFF
--- a/projects/habit_tracker_flutter/analysis_options.yaml
+++ b/projects/habit_tracker_flutter/analysis_options.yaml
@@ -20,9 +20,6 @@
 include: all_lint_rules.yaml
 
 analyzer:
-  strong-mode:
-    implicit-casts: false
-    implicit-dynamic: false
   errors:
     # Otherwise cause the import of all_lint_rules to warn because of some rules conflicts.
     # The conflicts are fixed in this file instead, so we can safely ignore the warning.

--- a/projects/habit_tracker_flutter/ios/Runner.xcodeproj/project.pbxproj
+++ b/projects/habit_tracker_flutter/ios/Runner.xcodeproj/project.pbxproj
@@ -204,6 +204,7 @@
 			files = (
 			);
 			inputPaths = (
+				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
 			);
 			name = "Thin Binary";
 			outputPaths = (

--- a/projects/habit_tracker_flutter/lib/ui/add_task/task_details_page.dart
+++ b/projects/habit_tracker_flutter/lib/ui/add_task/task_details_page.dart
@@ -112,7 +112,7 @@ class _ConfirmTaskContentsState extends ConsumerState<ConfirmTaskContents> {
       actions: <BottomSheetAction>[
         BottomSheetAction(
           title: const Text('Delete'),
-          onPressed: () => Navigator.of(context).pop(true),
+          onPressed: (context) => Navigator.of(context).pop(true),
         ),
       ],
       cancelAction: CancelAction(

--- a/projects/habit_tracker_flutter/lib/ui/onboarding/onboarding_page.dart
+++ b/projects/habit_tracker_flutter/lib/ui/onboarding/onboarding_page.dart
@@ -28,7 +28,7 @@ class OnboardingPage extends StatelessWidget {
     // * This page only shows on app startup until the first task is added,
     // * so it's ok to choose a default swatch and app theme.
     // * The user will be able to customize this later.
-    final defaultColorSwatch = AppColors.red;
+    const defaultColorSwatch = AppColors.red;
     final defaultAppThemeVariants = AppThemeVariants(defaultColorSwatch);
     final appThemeData = defaultAppThemeVariants.themes[0];
     return AppTheme(

--- a/projects/habit_tracker_flutter/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/projects/habit_tracker_flutter/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,7 +5,7 @@
 import FlutterMacOS
 import Foundation
 
-import path_provider_macos
+import path_provider_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))

--- a/projects/habit_tracker_flutter/pubspec.yaml
+++ b/projects/habit_tracker_flutter/pubspec.yaml
@@ -18,27 +18,30 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.13.0 <3.0.0"
+  sdk: ">=2.19.0 <3.0.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  adaptive_action_sheet: ^2.0.1
-  cupertino_icons: ^1.0.4
-  flutter_launcher_icons: ^0.9.2
+  adaptive_action_sheet: ^2.0.2
+  cupertino_icons: ^1.0.5
+  flutter_launcher_icons: ^0.13.1
   flutter_riverpod: ^1.0.3
-  flutter_svg: ^1.0.1
-  hive: ^2.0.5
+  flutter_svg: ^1.1.6
+  hive: ^2.2.3
   hive_flutter: ^1.1.0
   modal_bottom_sheet: ^2.1.0
   page_flip_builder: 0.1.3
-  uuid: ^3.0.5
+  uuid: ^3.0.7
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  build_runner: ^2.1.7
-  hive_generator: ^1.1.2
+  build_runner: ^2.4.1
+  hive_generator: ^2.0.0
+
+dependency_overrides:
+  modal_bottom_sheet: ^3.0.0-pre
 
 flutter_icons:
   ios: true

--- a/projects/stopwatch_flutter/ios/Flutter/AppFrameworkInfo.plist
+++ b/projects/stopwatch_flutter/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>8.0</string>
+  <string>11.0</string>
 </dict>
 </plist>

--- a/projects/stopwatch_flutter/ios/Runner.xcodeproj/project.pbxproj
+++ b/projects/stopwatch_flutter/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -127,7 +127,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1020;
+				LastUpgradeCheck = 1300;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
@@ -171,6 +171,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -185,6 +186,7 @@
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -272,7 +274,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -349,7 +351,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -398,7 +400,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;

--- a/projects/stopwatch_flutter/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/projects/stopwatch_flutter/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1300"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/projects/stopwatch_flutter/ios/Runner/Info.plist
+++ b/projects/stopwatch_flutter/ios/Runner/Info.plist
@@ -41,5 +41,9 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Updated habit tracker app to latest packages (apart from riverpod and flutter_svg)

Updated packages list:

```yaml
environment:
  sdk: ">=2.19.0 <3.0.0"

dependencies:
  flutter:
    sdk: flutter
  adaptive_action_sheet: ^2.0.2
  cupertino_icons: ^1.0.5
  flutter_launcher_icons: ^0.13.1
  flutter_riverpod: ^1.0.3 # still outdated
  flutter_svg: ^1.1.6 # still outdated
  hive: ^2.2.3
  hive_flutter: ^1.1.0
  modal_bottom_sheet: ^2.1.0
  page_flip_builder: 0.1.3
  uuid: ^3.0.7

dev_dependencies:
  flutter_test:
    sdk: flutter
  build_runner: ^2.4.1
  hive_generator: ^2.0.0

dependency_overrides:
  modal_bottom_sheet: ^3.0.0-pre
```